### PR TITLE
Fixes building with newer versions of wlroots

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -24,6 +24,7 @@ endif
 
 # Hiding depreciation warnings
 add_project_arguments('-DWL_HIDE_DEPRECATED', language: 'c')
+add_project_arguments('-DWLR_USE_UNSTABLE', language: 'c')
 
 # Adding include directory
 inc_dir = include_directories('include')


### PR DESCRIPTION
Most wlroots headers are still unstable and to use them we need to
define WLR_USE_UNSTABLE.