### PR TITLE
Makes compilable with wlroots 0.9+

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -30,7 +30,7 @@ add_project_arguments('-DWL_HIDE_DEPRECATED', language: 'c')
 inc_dir = include_directories('include')
 
 pixman = dependency('pixman-1')
-wlroots = dependency('wlroots', version: '>=0.6.0')
+wlroots = dependency('wlroots', version: '>=0.9.0')
 wayland_server = dependency('wayland-server')
 wayland_client = dependency('wayland-client')
 wayland_protos  = dependency('wayland-protocols', version: '>=1.12')

--- a/waybox/output.c
+++ b/waybox/output.c
@@ -16,25 +16,6 @@ void output_frame_notify(struct wl_listener *listener, void *data) {
 	float color[4] = {0.4f, 0.4f, 0.4f, 1.0f};
 	wlr_renderer_clear(renderer, color);
 
-	struct wl_resource *_surface;
-	wl_resource_for_each(_surface, &output->server->compositor->surface_resources) {
-		struct wlr_surface *surface = wlr_surface_from_resource(_surface);
-		if (!wlr_surface_has_buffer(surface)) {
-			continue;
-		}
-		struct wlr_box render_box = {
-			.x = 20, .y = 20,
-			.width = surface->current.width,
-			.height = surface->current.height
-		};
-		float matrix[16];
-        wlr_matrix_project_box(matrix, &render_box, surface->current.transform,
-			    0, wlr_output->transform_matrix);
-		struct wlr_texture *texture = wlr_surface_get_texture(surface);
-	    wlr_render_texture_with_matrix(renderer, texture, matrix, 1.0f);
-	    wlr_surface_send_frame_done(surface, &now);
-	}
-
 	wlr_output_commit(wlr_output);
 	wlr_renderer_end(renderer);
 	output->last_frame = now;


### PR DESCRIPTION
Removes code for functionality removed in wlroots 0.9.  It doesn't seem to break anything, though its functionality may have to reimplemented in a more modern way down the line.